### PR TITLE
Filter descriptors for valid 3d points

### DIFF
--- a/hfnet/evaluation/utils/db_management.py
+++ b/hfnet/evaluation/utils/db_management.py
@@ -88,6 +88,8 @@ def build_localization_dbs(db_ids, images, cameras,
                 pred = config_local['predictor'](
                     data['image'], data['name'], **config)
                 desc = pred['descriptors']
+                if desc.shape[0] != len(valid):
+                    desc = desc[valid]
             elif 'colmap_db' in config_local:
                 cursor = get_cursor(config_local['colmap_db'])
                 if config_local.get('broken_db', False):


### PR DESCRIPTION
Hi!

Thank you for making hfnet publicly available.

The following problem occurred when I tried to use r2d2 together with hfnet: 
The number of descriptors loaded from file for a single image (5000) did not match the number of 3d points retrieved (e.g. 1113).
Therefore `match_against_place` failed in line [103](https://github.com/ethz-asl/hfnet/blob/8fd6080252d48814bf9facfb07400d3aef91972b/hfnet/evaluation/utils/localization.py#L103).

Could it be, that the loaded descriptors ought to be filtered by the "valid" mask?

Kind regards
Daniel


